### PR TITLE
Add Maven and Docker configuration for running WzCompiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.env
+.bash_history
+target/

--- a/CompileAllMaven.sh
+++ b/CompileAllMaven.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# The entrypoint for the docker container. This is a copy of the CompileAll.sh
+# script with modifications to run via maven.
+
+IN=${DATA_DIR:-wz/}
+OUT=${OUTPUT_DIR:-out/}
+LOG="wzlog.txt"
+
+mvn exec:java -Dexec.mainClass="kvjcompiler.WzCompiler" \
+    -Dexec.args="-i "$IN" -o "$OUT" -l "$LOG" \
+        -f String.wz \
+        -f Quest.wz \
+        -f Skill.wz \
+        -f Reactor.wz \
+        -f Npc.wz \
+        -f Mob.wz \
+        -f Item.wz \
+        -f Character.wz \
+        -f Map.wz \
+        -d custom_drops.txt \
+        -m no_mesos.txt \
+        -q quest_drops.txt \
+    "

--- a/CompileAllMaven.sh
+++ b/CompileAllMaven.sh
@@ -8,15 +8,16 @@ LOG="wzlog.txt"
 
 mvn exec:java -Dexec.mainClass="kvjcompiler.WzCompiler" \
     -Dexec.args="-i "$IN" -o "$OUT" -l "$LOG" \
-        -f String.wz \
-        -f Quest.wz \
-        -f Skill.wz \
-        -f Reactor.wz \
-        -f Npc.wz \
-        -f Mob.wz \
-        -f Item.wz \
         -f Character.wz \
+        -f Etc.wz \
+        -f Item.wz \
         -f Map.wz \
+        -f Mob.wz \
+        -f Npc.wz \
+        -f Quest.wz \
+        -f Reactor.wz \
+        -f Skill.wz \
+        -f String.wz \
         -d custom_drops.txt \
         -m no_mesos.txt \
         -q quest_drops.txt \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM openjdk:8
+
+RUN apt-get update && apt-get install -y maven
+ENV HOME=/app
+WORKDIR /app
+COPY pom.xml pom.xml
+RUN mvn dependency:go-offline
+ADD . /app
+RUN mvn package
+
+CMD [ "/app/CompileAllMaven.sh" ]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# kvjcompiler
+
 If your XML WZ files are not in a folder named "wz" in your root directory, then
 you will have to edit the batch file (on Windows), or the bash file (on Linux).
 Likewise, you will have to edit those files if you want to change where the
@@ -6,6 +8,19 @@ file. Make sure that if you are using Windows and need to put backspaces in the
 path that you escape them (just double each backspace) so that Java understands
 that it is not an escape sequence. Unlike in earlier revisions, the paths do not
 have to have a trailing directory delimiter, but you should place one anyway.
+
+You may also run the compiler on the data directory using docker.
+
+```bash
+# Path to the XML WZ files
+export DATA_DIR=../wz
+export OUTPUT_DIR=../wz-kvj
+docker-compose build
+docker-compose run app
+```
+
+The environment variables may be put into a `.env` file at the root of the
+directory.
 
 No external libraries are necessary. The only API needed is StAX (Streaming API
 for XML), which should be included with JRE 6 and later. An independent

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3.4"
+
+services:
+  app:
+    build:
+      context: .
+    volumes:
+      - ${DATA_DIR}:/app/wz
+      - ${OUTPUT_DIR}:/app/out

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,11 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 
+	      http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>argonms</groupId>
+    <artifactId>kvjcompiler</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+
+    <build>
+        <sourceDirectory>src/kvjcompiler</sourceDirectory>
+    </build>
+</project>


### PR DESCRIPTION
This adds a Maven configuration file for building the project. It also adds a Dockerfile and docker-compose configuration as an alternative method of compiling assets. There's probably a significant amount of slow-down while running on Docker in Windows, but it's functional: `Processing completed in 288095ms!`